### PR TITLE
[BUGFIX] Deprecation warning for PHP4-style named constructor

### DIFF
--- a/classes/class.tx_icsawstats_awstats.php
+++ b/classes/class.tx_icsawstats_awstats.php
@@ -51,7 +51,7 @@ class tx_icsawstats_awstats {
 	public static $LOGF_CHECKED = 4;
 
 	// constructor
-	function tx_icsawstats_awstats() {
+	public function __construct() {
 		global $TYPO3_CONF_VARS;
 
 		$this->ext_conf = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['ics_awstats']);
@@ -72,6 +72,10 @@ class tx_icsawstats_awstats {
 		}
 		$this->conf['awstats_data_dir'] = $this->conf['logfile_dir'] .'.awstats-data/';
 		$this->conf['awstats_conf'] = $this->conf['awstats_data_dir'].'awstats-module.conf';
+	}
+	
+	public function tx_icsawstats_awstats() {
+		self::__construct();
 	}
 
 	function get_perlbin() {


### PR DESCRIPTION
A backward compatible non-breaking resolution for PHP4-Style named constructor problem in top of classes/class.tx_icsawstats_awstats.php